### PR TITLE
Starts With 'application/json'

### DIFF
--- a/bottle_jwt/auth.py
+++ b/bottle_jwt/auth.py
@@ -143,7 +143,7 @@ class JWTProvider(object):
             BackendError, if an auth backend error occurs.
             JWTProviderError,, if user can't be authorized.
         """
-        if request.content_type == 'application/json':  # pragma: no cover
+        if request.content_type.startswith('application/json'):  # pragma: no cover
             user_uid = request.json.get(self.user_field.user_id)
             user_secret = request.json.get(self.user_field.password)
         else:


### PR DESCRIPTION
Added a change to the check so that clients sending ‘Content-Type:
application/json; charset=utf-8’ (which I know is redundant for the
coding but they do it anyway), will be accepted and work.
